### PR TITLE
Testing

### DIFF
--- a/zip_keyed_test/arg-lengths-all-modes.js
+++ b/zip_keyed_test/arg-lengths-all-modes.js
@@ -1,0 +1,72 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed respects the different modes: shortest, longest, and strict.
+info: |
+  - In "shortest" mode (default), the iterator stops when the shortest iterable is exhausted.
+  - In "longest" mode, padding is used when shorter iterables are exhausted.
+  - In "strict" mode, an error is thrown if the iterables do not have the same length.
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    long: [1, 2, 3, 4],
+    short: ['a', 'b']
+  };
+  
+  // Default mode: "shortest"
+  let iterator = Iterator.zipKeyed(input);
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.sameValue(result.value.long, 1, "First value for 'long' should be 1");
+  assert.sameValue(result.value.short, 'a', "First value for 'short' should be 'a'");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.sameValue(result.value.long, 2, "Second value for 'long' should be 2");
+  assert.sameValue(result.value.short, 'b', "Second value for 'short' should be 'b'");
+  
+  // Stops at shortest iterable
+  result = iterator.next();
+  assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+  assert.sameValue(result.done, true, "Iterator should be done after shortest iterable ends");
+  
+  // Longest mode with padding
+  iterator = Iterator.zipKeyed(input, {
+    mode: "longest",
+    padding: { short: null, long: null }
+  });
+  
+  result = iterator.next();
+  assert.sameValue(result.value.long, 1);
+  assert.sameValue(result.value.short, 'a');
+  
+  result = iterator.next();
+  assert.sameValue(result.value.long, 2);
+  assert.sameValue(result.value.short, 'b');
+  
+  result = iterator.next();
+  assert.sameValue(result.value.long, 3, "Longer continues; shorter padded");
+  assert.sameValue(result.value.short, null);
+  
+  result = iterator.next();
+  assert.sameValue(result.value.long, 4);
+  assert.sameValue(result.value.short, null);
+  
+  result = iterator.next();
+  assert.sameValue(result.done, true, "Longest iterable exhausted");
+  assert.sameValue(result.value, undefined);
+  
+  // Strict mode: throws if lengths differ
+  assert.throws(TypeError, () => {
+    iterator = Iterator.zipKeyed(input, { mode: "strict" });
+    iterator.next();
+  }, "Strict mode should throw if property iterables have different lengths");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/closing-iterators.js
+++ b/zip_keyed_test/closing-iterators.js
@@ -1,0 +1,150 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that iterators are properly closed via .return() in various cases.
+info: |
+  - Errors before accessing values should not close anything.
+  - Errors from one iterable do not close that iterator, but others may be closed.
+  - "shortest" or "strict" modes close remaining iterators when one is exhausted.
+  - "longest" mode does not close iterators that are already exhausted.
+  - .return() is called with the correct receiver.
+features: [iterator-sequencing]
+---*/
+
+function createIterator(values, label) {
+    let index = 0;
+    let closed = false;
+    return {
+      next() {
+        if (index < values.length) {
+          return { value: values[index++], done: false };
+        }
+        return { done: true };
+      },
+      return() {
+        closed = true;
+        return { done: true };
+      },
+      get closed() {
+        return closed;
+      }
+    };
+  }
+  
+  // --- ERROR CASE: invalid input ---
+  
+  assert.throws(TypeError, () => {
+    Iterator.zipKeyed(null);
+  }, "Invalid first argument should not trigger .return()");
+  
+  // --- ERROR CASE: one iterator throws during next(), others should close ---
+  
+  let badIterable = {
+    get a() {
+      return {
+        [Symbol.iterator]() {
+          return {
+            next() {
+              throw new Error("Iterator contract broken");
+            },
+            return() {
+              throw new Error("Should not be called");
+            }
+          };
+        }
+      };
+    },
+    get b() {
+      const iter = createIterator([1, 2], "safe");
+      Object.defineProperty(this, "_b_iter", { value: iter });
+      return iter;
+    }
+  };
+  
+  assert.throws(() => {
+    Iterator.zipKeyed(badIterable).next();
+  }, Error, "Iterator contract broken");
+  
+  assert.sameValue(badIterable._b_iter.closed, true, "Safe iterator should be closed");
+  
+  // --- SHORTEST MODE ---
+  
+  let shortIter = createIterator([1, 2], "short");
+  let longIter = createIterator([10, 20, 30], "long");
+  
+  let zip = Iterator.zipKeyed({ short: shortIter, long: longIter }, { mode: "shortest" });
+  
+  zip.next();
+  zip.next();
+  let final = zip.next();
+  
+  assert.sameValue(final.done, true);
+  assert.sameValue(longIter.closed, true, "Long iterator should be closed when short ends");
+  assert.sameValue(shortIter.closed, false, "Short iterator should not be closed");
+  
+  // --- STRICT MODE ---
+  
+  shortIter = createIterator([1, 2], "short");
+  longIter = createIterator([10, 20, 30], "long");
+  
+  zip = Iterator.zipKeyed({ short: shortIter, long: longIter }, { mode: "strict" });
+  
+  zip.next();
+  zip.next();
+  final = zip.next();
+  
+  assert.sameValue(final.done, true);
+  assert.sameValue(longIter.closed, true, "Long iterator should be closed");
+  assert.sameValue(shortIter.closed, false, "Short iterator should not be closed");
+  
+  // --- LONGEST MODE ---
+  
+  let iter1 = createIterator([1, 2, 3], "iter1");
+  let iter2 = createIterator([10, 20], "iter2");
+  
+  zip = Iterator.zipKeyed({ one: iter1, two: iter2 }, {
+    mode: "longest",
+    padding: { one: null, two: null }
+  });
+  
+  zip.next();
+  zip.next();
+  zip.next(); // triggers padding for `two`
+  
+  assert.sameValue(iter1.closed, false, "Iterator 1 should not be closed");
+  assert.sameValue(iter2.closed, true, "Iterator 2 should be closed after natural exhaustion");
+  
+  // --- .return() RECEIVER CHECK ---
+  
+  let returnSpy = [];
+  let trackedIterable = {
+    [Symbol.iterator]() {
+      let obj = {
+        next() {
+          return { value: 42, done: false };
+        },
+        return() {
+          returnSpy.push(this);
+          return { done: true };
+        }
+      };
+      return obj;
+    }
+  };
+  
+  shortIter = createIterator([1], "short");
+  
+  zip = Iterator.zipKeyed({ a: trackedIterable, b: shortIter });
+  
+  zip.next();
+  zip.return();
+  
+  assert.sameValue(returnSpy.length, 1, ".return() should have been called once");
+  assert.sameValue(typeof returnSpy[0], "object", ".return() should have been called with correct receiver");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/empty-iterables.js
+++ b/zip_keyed_test/empty-iterables.js
@@ -1,0 +1,31 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Iterator.zipKeyed returns a finished iterator immediately when all property values are empty.
+info: |
+  - If all values are valid iterables, but empty, then .next() returns { done: true } immediately.
+features: [iterator-sequencing]
+---*/
+
+let obj = {
+    a: [],
+    b: [],
+    c: []
+  };
+  
+  let iter = Iterator.zipKeyed(obj);
+  
+  let result = iter.next();
+  assert.sameValue(result.done, true, "Iterator should be done immediately if all values are empty");
+  assert.sameValue(result.value, undefined, "Value should be undefined when done is true");
+  
+  result = iter.next();
+  assert.sameValue(result.done, true, "Iterator should remain done on subsequent calls");
+  assert.sameValue(result.value, undefined, "Subsequent value should remain undefined");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/first-arg-longer.js
+++ b/zip_keyed_test/first-arg-longer.js
@@ -1,0 +1,38 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed stops when the shortest iterable is exhausted.
+info: |
+  - When values have different lengths and no options are given,
+    the iterator stops when the shortest is exhausted (default "shortest" mode).
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    longer: [1, 2, 3, 4],
+    shorter: ['a', 'b']
+  };
+  
+  let iterator = Iterator.zipKeyed(input);
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.sameValue(result.value.longer, 1, "First value for 'longer' should be 1");
+  assert.sameValue(result.value.shorter, 'a', "First value for 'shorter' should be 'a'");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.sameValue(result.value.longer, 2, "Second value for 'longer' should be 2");
+  assert.sameValue(result.value.shorter, 'b', "Second value for 'shorter' should be 'b'");
+  
+  // Should stop because 'shorter' is exhausted
+  result = iterator.next();
+  assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+  assert.sameValue(result.done, true, "Iterator should be done after shortest iterable is exhausted");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/first-argument-non-object.js
+++ b/zip_keyed_test/first-argument-non-object.js
@@ -1,0 +1,31 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Throws a TypeError if the first argument to Iterator.zipKeyed is not an object.
+info: |
+  Iterator.zipKeyed( iterables [, options] )
+  
+  - If the first argument is not an object (including if it is a string), a TypeError must be thrown.
+features: [iterator-sequencing]
+---*/
+
+let nonObjects = [
+    null,
+    undefined,
+    42,
+    true,
+    "Hello World!",
+    Symbol("test")
+  ];
+  
+  for (let value of nonObjects) {
+    assert.throws(TypeError, () => Iterator.zipKeyed(value),
+      `Expected TypeError for iterables value: ${String(value)}`);
+  }
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/fresh-outputs.js
+++ b/zip_keyed_test/fresh-outputs.js
@@ -1,0 +1,34 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that each object returned by Iterator.zipKeyed is a fresh object with a different identity.
+info: |
+  - Each call to `.next()` must return a new result object.
+  - The `value` property of each result must also be a unique object (not reused).
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    num: [1, 2, 3],
+    char: ['a', 'b', 'c']
+  };
+  
+  let iterator = Iterator.zipKeyed(input);
+  
+  let firstResult = iterator.next();
+  let secondResult = iterator.next();
+  
+  assert.notSameValue(firstResult, secondResult, "Each result object should be a fresh object");
+  assert.notSameValue(firstResult.value, secondResult.value, "Each value object should be distinct");
+  
+  let thirdResult = iterator.next();
+  
+  assert.notSameValue(secondResult, thirdResult, "Each result object should be a fresh object");
+  assert.notSameValue(secondResult.value, thirdResult.value, "Each value object should be distinct");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/inherited-keys-not-used.js
+++ b/zip_keyed_test/inherited-keys-not-used.js
@@ -1,0 +1,29 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Confirm inherited keys are not used by Iterator.zipKeyed.
+info: |
+  When an object with only inherited enumerable keys is passed to
+  Iterator.zipKeyed, the algorithm should ignore those keys and produce
+  an iterator that is already done.
+features: [iterator-sequencing]
+---*/
+
+let proto = { inheritedKey: [1, 2, 3] }; // inherited enumerable key
+let obj = Object.create(proto);          // obj has no own enumerable keys
+
+let iter = Iterator.zipKeyed(obj);
+
+// The first call to next() should immediately indicate that the iterator is finished.
+let result = iter.next();
+assert.sameValue(result.done, true, "Iterator.zipKeyed should ignore inherited keys and finish immediately");
+
+// Confirm subsequent next() calls remain finished.
+result = iter.next();
+assert.sameValue(result.done, true, "Subsequent next() calls on a finished iterator should remain finished");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/iterables-are-strings.js
+++ b/zip_keyed_test/iterables-are-strings.js
@@ -1,0 +1,41 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed throws if any value is a string, but only after reading padding.
+info: |
+  Iterator.zipKeyed ( iterables [, options] )
+
+  - String values should not be considered valid flattenable iterables.
+  - When mode is "longest", padding must be read before throwing for invalid values.
+features: [iterator-sequencing]
+---*/
+
+let paddingAccessed = false;
+let options = {
+  mode: "longest",
+  get padding() {
+    paddingAccessed = true;
+    return { a: "PAD", b: "PAD" };
+  }
+};
+
+// Strings should cause a TypeError, but padding should be read first
+let invalidInput = {
+  a: [],
+  b: "not an iterable"
+};
+
+assert.throws(TypeError, () => Iterator.zipKeyed(invalidInput, options),
+  "Expected TypeError when a string is passed as a value");
+
+assert.sameValue(paddingAccessed, true, "Padding should be accessed before throwing for invalid values");
+
+// Valid cases should not throw
+Iterator.zipKeyed({ a: [], b: [] }, { mode: "longest", padding: { a: 0, b: 0 } });
+Iterator.zipKeyed({ a: [], b: [] }, { mode: "shortest" }); // No padding read in shortest mode
+
+reportCompare(0, 0);

--- a/zip_keyed_test/key-enumeration.js
+++ b/zip_keyed_test/key-enumeration.js
@@ -1,0 +1,37 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Iterator.zipKeyed respects JS property key enumeration order:
+  integer-like keys in ascending order, then string keys in insertion order.
+info: |
+  - Property keys "2", "1", "0" should be ordered numerically.
+  - Non-integer string keys should follow in insertion order.
+features: [iterator-sequencing]
+---*/
+
+let obj = {
+    "2": ['a'],
+    "1": ['b'],
+    "0": ['c'],
+    x: ['X'],
+    y: ['Y']
+  };
+  
+  let expectedOrder = ["0", "1", "2", "x", "y"];
+  let seenOrder = [];
+  
+  let iter = Iterator.zipKeyed(obj);
+  let { value, done } = iter.next();
+  
+  for (let key of Object.keys(value)) {
+    seenOrder.push(key);
+  }
+  
+  assert.compareArray(seenOrder, expectedOrder, "Keys should be ordered per JS property enumeration rules");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/mode-from-second.js
+++ b/zip_keyed_test/mode-from-second.js
@@ -1,0 +1,27 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that the mode is correctly read from the second argument (options).
+info: |
+  Iterator.zipKeyed( iterables [, options] )
+
+  - The mode should be read from options.mode.
+  - If mode is not provided, it defaults to "shortest".
+features: [iterator-sequencing]
+---*/
+
+let input = { a: [1, 2], b: [3, 4] };
+
+let iter1 = Iterator.zipKeyed(input, { mode: "longest" });
+let iter2 = Iterator.zipKeyed(input, { mode: "shortest" });
+let iter3 = Iterator.zipKeyed(input);
+
+assert.sameValue(iter1.mode, "longest",  "Mode should be 'longest' when explicitly set.");
+assert.sameValue(iter2.mode, "shortest", "Mode should be 'shortest' when explicitly set.");
+assert.sameValue(iter3.mode, "shortest", "Mode should default to 'shortest' when not provided.");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/mode-not-read.js
+++ b/zip_keyed_test/mode-not-read.js
@@ -1,0 +1,53 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that mode is not read if the first argument is not an object.
+info: |
+  Iterator.zipKeyed ( iterables [, options] )
+
+  - If the first argument (iterables) is not an object, a TypeError is thrown.
+  - `mode` must not be accessed if the first argument is invalid.
+features: [iterator-sequencing]
+---*/
+
+let invalidIterables = [
+    null,
+    undefined,
+    420,
+    "notAnObject",
+    true,
+    Symbol("test"),
+    () => {}
+  ];
+  
+  let optionsGetterCalled = false;
+  let options = {
+    get mode() {
+      optionsGetterCalled = true;
+      return "shortest";
+    }
+  };
+  
+  // Ensure TypeError is thrown before mode is accessed
+  for (let value of invalidIterables) {
+    optionsGetterCalled = false;
+    assert.throws(TypeError, () => Iterator.zipKeyed(value, options),
+      `Expected TypeError for first argument: ${String(value)}`);
+    assert.sameValue(
+      optionsGetterCalled,
+      false,
+      "Mode should not be accessed if first argument is invalid"
+    );
+  }
+  
+  // Valid case: mode should be read
+  optionsGetterCalled = false;
+  Iterator.zipKeyed({ a: [] }, options);
+  assert.sameValue(optionsGetterCalled, true, "Mode should be accessed when first argument is valid");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/mode-object.js
+++ b/zip_keyed_test/mode-object.js
@@ -1,0 +1,46 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that the mode option is not coerced to a string and throws for invalid types.
+info: |
+  Iterator.zipKeyed( iterables [, options] )
+
+  - The mode option must be exactly "shortest", "longest", or "strict".
+  - If mode is not a valid string, a TypeError must be thrown.
+  - Non-string values should not be coerced.
+features: [iterator-sequencing]
+---*/
+
+let invalidModes = [
+    0,
+    1,
+    true,
+    false,
+    "short",    
+    "FooBar",
+    {},         
+    [],         
+    null,
+    undefined,
+    Symbol("test")
+  ];
+  
+  for (let value of invalidModes) {
+    assert.throws(
+      TypeError,
+      () => Iterator.zipKeyed({ a: [] }, { mode: value }),
+      `Expected TypeError for mode: ${String(value)}`
+    );
+  }
+  
+  // Valid modes
+  Iterator.zipKeyed({ a: [] }, { mode: "shortest" });
+  Iterator.zipKeyed({ a: [] }, { mode: "longest" });
+  Iterator.zipKeyed({ a: [] }, { mode: "strict" });
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/no-keys-finished.js
+++ b/zip_keyed_test/no-keys-finished.js
@@ -1,0 +1,25 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Object with no own-enumerable keys as argument produces iterator which is finished
+info: |
+  When an object with no own-enumerable keys is passed to Iterator.zipKeyed,
+  it should produce an iterator that is already done.
+features: [iterator-sequencing]
+---*/
+
+let iter = Iterator.zipKeyed({});
+
+// First call to next() must yield a result with done:true.
+let result = iter.next();
+assert.sameValue(result.done, true, "Iterator.zipKeyed on an object with no own-enumerable keys should be finished");
+
+// Even subsequent calls should return done:true.
+result = iter.next();
+assert.sameValue(result.done, true, "Subsequent next() calls on a finished iterator should still be finished");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/non-enum-keys-not-used.js
+++ b/zip_keyed_test/non-enum-keys-not-used.js
@@ -1,0 +1,30 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Confirm non-enumerable keys are not used by Iterator.zipKeyed.
+info: |
+  When an object with non-enumerable own keys is passed to Iterator.zipKeyed,
+  those keys should be ignored, and the resulting iterator should be finished.
+features: [iterator-sequencing]
+---*/
+
+let obj = {};
+Object.defineProperty(obj, "nonEnumKey", {
+  value: [1, 2, 3],
+  enumerable: false
+});
+
+let iter = Iterator.zipKeyed(obj);
+
+let result = iter.next();
+assert.sameValue(result.done, true, "Iterator.zipKeyed should ignore non-enumerable keys and finish immediately");
+
+// Confirm subsequent next() calls remain finished.
+result = iter.next();
+assert.sameValue(result.done, true, "Subsequent next() calls on a finished iterator should remain finished");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/order-of-properties.js
+++ b/zip_keyed_test/order-of-properties.js
@@ -1,0 +1,33 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  The order of properties reported by Object.keys() on the output object is the same as
+  that of the own enumerable properties on the input object.
+info: |
+  The keys are collected using a method like Reflect.ownKeys() in the order defined
+  on the input object, and the output object preserves that order.
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    first: [1, 2],
+    second: [3, 4],
+    third: [5, 6]
+  };
+  
+  let expectedOrder = Object.keys(input);  // e.g., ["first", "second", "third"]
+  
+  let iter = Iterator.zipKeyed(input);
+  let result = iter.next();
+  assert.sameValue(result.done, false, "Iterator.zipKeyed should yield a result");
+  
+  let outObj = result.value;
+  assert.compareArray(Object.keys(outObj), expectedOrder,
+    "The order of keys on the output object should match the order on the input");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/output-correct-attributes.js
+++ b/zip_keyed_test/output-correct-attributes.js
@@ -1,0 +1,57 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Ensure that output objects have properties with writable and configurable attributes,
+  even if the input properties are not writable/configurable.
+info: |
+  When Iterator.zipKeyed is called, it creates new output objects via a helper that
+  defines each property using DefineDataProperty. As a result, each property on
+  the output object should be writable and configurable.
+features: [iterator-sequencing]
+---*/
+
+let input = {};
+// Define a non-writable, non-configurable, yet enumerable property "a"
+Object.defineProperty(input, "a", {
+  value: [1, 2, 3],
+  writable: false,
+  configurable: false,
+  enumerable: true
+});
+
+// Create a zipped iterator from the input object.
+// For key "a", the iterable is [1, 2, 3], so the zipped iterator will yield
+// an object for each element.
+let iter = Iterator.zipKeyed(input);
+
+// Get the first result
+let result = iter.next();
+assert.sameValue(result.done, false, "Iterator.zipKeyed should yield at least one result");
+
+let outObj = result.value;
+
+// The output object should have property "a"
+assert("a" in outObj, "Output object should have key 'a'");
+
+// Get the property descriptor for "a" from the output object.
+let desc = Object.getOwnPropertyDescriptor(outObj, "a");
+assert(desc.writable, "Output property 'a' should be writable");
+assert(desc.configurable, "Output property 'a' should be configurable");
+
+// Additionally, test that the property is actually writable and configurable.
+// Save the old value (expected to be the first value of the zipped iterator, 1).
+let oldValue = outObj.a;
+
+// Modify the property's value.
+outObj.a = "new value";
+assert.notSameValue(outObj.a, oldValue, "Output property 'a' is writable");
+
+// Delete the property.
+delete outObj.a;
+assert.sameValue(outObj.a, undefined, "Output property 'a' is configurable; deletion succeeded");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/output-inherit-from-null.js
+++ b/zip_keyed_test/output-inherit-from-null.js
@@ -1,0 +1,25 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Output objects produced by Iterator.zipKeyed inherit from null.
+info: |
+  The internal finishResults function creates the output object using
+  Object.create(null), so it should not have a prototype.
+features: [iterator-sequencing]
+---*/
+
+let input = { a: [1] };
+let iter = Iterator.zipKeyed(input);
+
+let result = iter.next();
+assert.sameValue(result.done, false, "Iterator.zipKeyed should yield a result");
+
+let outObj = result.value;
+assert.sameValue(Object.getPrototypeOf(outObj), null,
+  "Output object should have a null prototype");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/padding-read-longest.js
+++ b/zip_keyed_test/padding-read-longest.js
@@ -1,0 +1,54 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that padding is read if and only if mode is "longest".
+info: |
+  Iterator.zipKeyed( iterables [, options] )
+
+  - If mode is "longest", padding is read from options.padding.
+  - If mode is not "longest", padding must not be accessed.
+features: [iterator-sequencing]
+---*/
+
+let paddingAccessed = false;
+
+// Mode "longest" should read padding
+let opts1 = {
+  mode: "longest",
+  get padding() {
+    paddingAccessed = true;
+    return { a: 0 };
+  }
+};
+Iterator.zipKeyed({ a: [] }, opts1);
+assert.sameValue(paddingAccessed, true, "Padding should be accessed when mode is 'longest'");
+
+// Mode "shortest" should not read padding
+paddingAccessed = false;
+let opts2 = {
+  mode: "shortest",
+  get padding() {
+    paddingAccessed = true;
+    return { a: 0 };
+  }
+};
+Iterator.zipKeyed({ a: [] }, opts2);
+assert.sameValue(paddingAccessed, false, "Padding should not be accessed when mode is 'shortest'");
+
+// Mode "strict" should not read padding
+paddingAccessed = false;
+let opts3 = {
+  mode: "strict",
+  get padding() {
+    paddingAccessed = true;
+    return { a: 0 };
+  }
+};
+Iterator.zipKeyed({ a: [] }, opts3);
+assert.sameValue(paddingAccessed, false, "Padding should not be accessed when mode is 'strict'");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/padding-three-iterables.js
+++ b/zip_keyed_test/padding-three-iterables.js
@@ -1,0 +1,97 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that in "longest" mode, Iterator.zipKeyed correctly applies padding with four properties.
+info: |
+  - When mode is "longest", shorter iterables are padded.
+  - Padding defaults to undefined if not provided.
+  - If padding is given, it applies only where necessary.
+features: [iterator-sequencing]
+---*/
+
+// Case 1: Explicit padding for all properties
+let input = {
+    a: [1, 2],
+    b: ['a'],
+    c: [true, false, false, true],
+    d: ['X', 'Y', 'Z']
+  };
+  
+  let iterator = Iterator.zipKeyed(input, {
+    mode: "longest",
+    padding: { a: 'P1', b: 'P2', c: 'P3', d: 'P4' }
+  });
+  
+  let result = iterator.next();
+  assert.compareArray(Object.values(result.value), [1, 'a', true, 'X'], "First zipped value");
+  assert.sameValue(result.done, false);
+  
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [2, 'P2', false, 'Y'], "Second zipped value with padding");
+  assert.sameValue(result.done, false);
+  
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), ['P1', 'P2', false, 'Z'], "Third zipped value with more padding");
+  assert.sameValue(result.done, false);
+  
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), ['P1', 'P2', true, 'P4'], "Fourth zipped value with continued padding");
+  assert.sameValue(result.done, false);
+  
+  result = iterator.next();
+  assert.sameValue(result.value, undefined);
+  assert.sameValue(result.done, true);
+  
+  // Case 2: Partial padding, rest default to undefined
+  input = {
+    a: [1, 2, 3],
+    b: ['a'],
+    c: [true, false],
+    d: ['X', 'Y']
+  };
+  
+  iterator = Iterator.zipKeyed(input, {
+    mode: "longest",
+    padding: { a: 'PAD1', b: 'PAD2' }
+  });
+  
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [1, 'a', true, 'X']);
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [2, 'PAD2', false, 'Y']);
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [3, 'PAD2', undefined, undefined]);
+  
+  result = iterator.next();
+  assert.sameValue(result.value, undefined);
+  assert.sameValue(result.done, true);
+  
+  // Case 3: No padding provided, default to undefined
+  input = {
+    a: [1, 2],
+    b: ['a', 'b', 'c'],
+    c: [true],
+    d: ['X', 'Y', 'Z', 'W']
+  };
+  
+  iterator = Iterator.zipKeyed(input, { mode: "longest" });
+  
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [1, 'a', true, 'X']);
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [2, 'b', undefined, 'Y']);
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [undefined, 'c', undefined, 'Z']);
+  result = iterator.next();
+  assert.compareArray(Object.values(result.value), [undefined, undefined, undefined, 'W']);
+  
+  result = iterator.next();
+  assert.sameValue(result.value, undefined);
+  assert.sameValue(result.done, true);
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/padding-when-mode-longest.js
+++ b/zip_keyed_test/padding-when-mode-longest.js
@@ -1,0 +1,142 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that in "longest" mode, Iterator.zipKeyed correctly applies padding.
+info: |
+  - When mode is "longest", shorter iterables are padded.
+  - Padding defaults to undefined if not provided.
+  - If padding is given, it applies only where necessary.
+features: [iterator-sequencing]
+---*/
+
+// Case 1: Explicit padding for all keys
+let input1 = {
+    one:   [1, 2],
+    two:   ['a'],
+    three: [true, false, false, true]
+  };
+  
+  let it1 = Iterator.zipKeyed(input1, {
+    mode:    "longest",
+    padding: { one: 'X', two: 'Y', three: 'Z' }
+  });
+  
+  let r = it1.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after first next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [1, 'a', true],
+    "First zipped value should be { one:1, two:'a', three:true }"
+  );
+  
+  r = it1.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after second next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [2, 'Y', false],
+    "Second zipped value should use explicit padding for 'two'"
+  );
+  
+  r = it1.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after third next()");
+  assert.compareArray(
+    Object.values(r.value),
+    ['X', 'Z', false],
+    "Third zipped value should pad 'one' and 'two' with 'X'/'Z'"
+  );
+  
+  r = it1.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after fourth next()");
+  assert.compareArray(
+    Object.values(r.value),
+    ['X', 'Z', true],
+    "Fourth zipped value should continue padding"
+  );
+  
+  r = it1.next();
+  assert.sameValue(r.done, true,  "Iterator should be done after all items are exhausted");
+  assert.sameValue(r.value, undefined, "Final value should be undefined when done");
+  
+  // Case 2: Some keys have explicit padding, others default to undefined
+  let input2 = {
+    one:   [1, 2, 3],
+    two:   ['a'],
+    three: [true, false]
+  };
+  
+  let it2 = Iterator.zipKeyed(input2, {
+    mode:    "longest",
+    padding: { two: 'PAD' }
+  });
+  
+  r = it2.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after first next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [1, 'a', true],
+    "First zipped value should be { one:1, two:'a', three:true }"
+  );
+  
+  r = it2.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after second next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [2, 'PAD', false],
+    "Second zipped value should pad 'two' with 'PAD'"
+  );
+  
+  r = it2.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after third next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [3, 'PAD', undefined],
+    "Third zipped value should pad 'three' with undefined"
+  );
+  
+  r = it2.next();
+  assert.sameValue(r.done, true,  "Iterator should be done after all items are exhausted");
+  assert.sameValue(r.value, undefined, "Final value should be undefined when done");
+  
+  // Case 3: No explicit padding, default to undefined
+  let input3 = {
+    one:   [1, 2],
+    two:   ['a', 'b', 'c'],
+    three: [true]
+  };
+  
+  let it3 = Iterator.zipKeyed(input3, { mode: "longest" });
+  
+  r = it3.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after first next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [1, 'a', true],
+    "First zipped value should be { one:1, two:'a', three:true }"
+  );
+  
+  r = it3.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after second next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [2, 'b', undefined],
+    "Second zipped value should pad 'three' with undefined"
+  );
+  
+  r = it3.next();
+  assert.sameValue(r.done, false, "Iterator should not be done after third next()");
+  assert.compareArray(
+    Object.values(r.value),
+    [undefined, 'c', undefined],
+    "Third zipped value should pad 'one' and 'three' with undefined"
+  );
+  
+  r = it3.next();
+  assert.sameValue(r.done, true,  "Iterator should be done after all items are exhausted");
+  assert.sameValue(r.value, undefined, "Final value should be undefined when done");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/prototype.js
+++ b/zip_keyed_test/prototype.js
@@ -1,0 +1,20 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Iterator.zipKeyed result has [[Prototype]] set to %IteratorHelperPrototype%.
+info: |
+  - The prototype of the resulting iterator should be %IteratorHelperPrototype%.
+  - %IteratorHelperPrototype% is the same as Object.getPrototypeOf(Iterator.from([]).take(0)).
+features: [iterator-sequencing]
+---*/
+
+let proto = Object.getPrototypeOf(Iterator.from([]).take(0));
+let zipped = Iterator.zipKeyed({ a: [], b: [] });
+
+assert.sameValue(Object.getPrototypeOf(zipped), proto, "Iterator.zipKeyed result should have %IteratorHelperPrototype% as prototype");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/second-arg-longer.js
+++ b/zip_keyed_test/second-arg-longer.js
@@ -1,0 +1,38 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed stops when the shortest iterable is exhausted.
+info: |
+  - When values have different lengths and no options are given,
+    the iterator stops when the shortest is exhausted (default "shortest" mode).
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    shorter: [1, 2],
+    longer: ['a', 'b', 'c', 'd']
+  };
+  
+  let iterator = Iterator.zipKeyed(input);
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.sameValue(result.value.shorter, 1, "First value for 'shorter' should be 1");
+  assert.sameValue(result.value.longer, 'a', "First value for 'longer' should be 'a'");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.sameValue(result.value.shorter, 2, "Second value for 'shorter' should be 2");
+  assert.sameValue(result.value.longer, 'b', "Second value for 'longer' should be 'b'");
+  
+  // Should stop because 'shorter' is exhausted
+  result = iterator.next();
+  assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+  assert.sameValue(result.done, true, "Iterator should be done after shortest iterable is exhausted");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/second-argument-non-object.js
+++ b/zip_keyed_test/second-argument-non-object.js
@@ -1,0 +1,36 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Throws a TypeError if the second argument to Iterator.zipKeyed is not an object and not null/undefined.
+info: |
+  Iterator.zipKeyed( iterables [, options] )
+
+  - If options is provided, it must be either an object or null/undefined.
+  - Any other type should result in a TypeError.
+features: [iterator-sequencing]
+---*/
+
+let validInput = { a: [1, 2, 3] };
+
+let invalidOptions = [
+  42,
+  false,
+  "Hello Mozilla!",
+  Symbol("test")
+];
+
+for (let value of invalidOptions) {
+  assert.throws(TypeError, () => Iterator.zipKeyed(validInput, value),
+    `Expected TypeError for options value: ${String(value)}`);
+}
+
+// Valid cases.
+Iterator.zipKeyed(validInput, undefined);
+Iterator.zipKeyed(validInput, null);
+Iterator.zipKeyed(validInput, {});
+
+reportCompare(0, 0);

--- a/zip_keyed_test/side-effect-order.js
+++ b/zip_keyed_test/side-effect-order.js
@@ -1,0 +1,87 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures the correct order of side effects in Iterator.zipKeyed.
+info: |
+  Iterator.zipKeyed ( iterables [, options] )
+
+  - Side effects should occur in a well-defined order.
+  - This test makes all side effects observable and checks the totality.
+features: [iterator-sequencing]
+---*/
+
+let log = [];
+
+// Create a getter-tracked options object
+let options = {
+  get mode() {
+    log.push("options.mode accessed");
+    return "longest";
+  },
+  get padding() {
+    log.push("options.padding accessed");
+    return { a: 0, b: 0 };
+  }
+};
+
+// Create a tracked getter that logs when the property is accessed
+function createTrackedIterable(name) {
+  return {
+    [Symbol.iterator]() {
+      log.push(`${name} iterator accessed`);
+      return {
+        next() {
+          log.push(`${name} next() called`);
+          return { done: true };
+        },
+        return() {
+          log.push(`${name} return() called`);
+          return { done: true };
+        }
+      };
+    }
+  };
+}
+
+// Define input object with tracked properties
+let input = {
+  get a() {
+    log.push("property 'a' accessed");
+    return createTrackedIterable("a");
+  },
+  get b() {
+    log.push("property 'b' accessed");
+    return createTrackedIterable("b");
+  }
+};
+
+// Call Iterator.zipKeyed and observe side effects
+log.push("Calling Iterator.zipKeyed");
+let iterator = Iterator.zipKeyed(input, options);
+
+// Assert immediately after calling .zipKeyed
+assert.compareArray(log, [
+  "Calling Iterator.zipKeyed",
+  "options.mode accessed",
+  "options.padding accessed",
+  "property 'a' accessed",
+  "a iterator accessed",
+  "property 'b' accessed",
+  "b iterator accessed"
+], "Side effects should occur in the expected order before calling .next");
+
+// Clear log and call .next on the result
+log = [];
+iterator.next();
+
+// Assert after calling .next
+assert.compareArray(log, [
+  "a next() called",
+  "b next() called"
+], "Side effects should occur in the expected order after calling .next");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/strict-same-length.js
+++ b/zip_keyed_test/strict-same-length.js
@@ -1,0 +1,41 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that in strict mode, Iterator.zipKeyed consumes all iterators fully when lengths match.
+info: |
+  - In "strict" mode, all property iterables must have the same length.
+  - .next() must still be called on all iterators to confirm full completion.
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    one: [1, 2, 3],
+    two: ['a', 'b', 'c'],
+    three: [true, false, null]
+  };
+  
+  let iterator = Iterator.zipKeyed(input, { mode: "strict" });
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.compareArray(Object.values(result.value), [1, 'a', true], "First zipped object values should be correct");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.compareArray(Object.values(result.value), [2, 'b', false], "Second zipped object values should be correct");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+  assert.compareArray(Object.values(result.value), [3, 'c', null], "Third zipped object values should be correct");
+  
+  // Ensure all iterators are fully consumed
+  result = iterator.next();
+  assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+  assert.sameValue(result.done, true, "Iterator should be done after all values are consumed");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/symbol-named-properties.js
+++ b/zip_keyed_test/symbol-named-properties.js
@@ -1,0 +1,34 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator-zipKeyed
+description: >
+  Iterator.zipKeyed correctly handles own enumerable properties with Symbol names.
+info: |
+  The algorithm should include symbol-named properties along with string-named properties,
+  and the output objects should reflect these keys.
+features: [iterator-sequencing]
+---*/
+
+let sym1 = Symbol("sym1");
+let sym2 = Symbol("sym2");
+
+let input = {};
+input[sym1] = [10, 20];
+input[sym2] = [30, 40];
+
+let iter = Iterator.zipKeyed(input);
+let result = iter.next();
+assert.sameValue(result.done, false, "Iterator.zipKeyed should yield a result");
+
+let outObj = result.value;
+let symbols = Object.getOwnPropertySymbols(outObj);
+
+assert(symbols.includes(sym1), "Output object should include the symbol sym1");
+assert(symbols.includes(sym2), "Output object should include the symbol sym2");
+assert.sameValue(outObj[sym1], 10, "Value for symbol sym1 should be 10");
+assert.sameValue(outObj[sym2], 30, "Value for symbol sym2 should be 30");
+
+reportCompare(0, 0);

--- a/zip_keyed_test/zip-one-thing.js
+++ b/zip_keyed_test/zip-one-thing.js
@@ -1,0 +1,40 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed can handle exactly one property.
+info: |
+  Iterator.zipKeyed ( iterables [, options] )
+
+  - When given an object with a single key, it should yield objects with one property.
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    only: [1, 2, 3]
+  };
+  
+  let iterator = Iterator.zipKeyed(input);
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.sameValue(Object.keys(result.value).length, 1, "Result should have one property");
+  assert.sameValue(result.value.only, 1, "First value should be { only: 1 }");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.sameValue(result.value.only, 2, "Second value should be { only: 2 }");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+  assert.sameValue(result.value.only, 3, "Third value should be { only: 3 }");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, true, "Iterator should be done after all elements are consumed");
+  assert.sameValue(result.value, undefined, "Final value should be undefined");
+  
+  reportCompare(0, 0);
+  

--- a/zip_keyed_test/zip-two-same-length.js
+++ b/zip_keyed_test/zip-two-same-length.js
@@ -1,0 +1,44 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zipKeyed||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zipKeyed
+description: >
+  Ensures that Iterator.zipKeyed correctly zips two keys with equal-length iterables.
+info: |
+  Iterator.zipKeyed ( iterables [, options] )
+
+  - When given two own-enumerable properties with equal-length iterables,
+    the iterator should yield objects pairing each key with its corresponding element.
+features: [iterator-sequencing]
+---*/
+
+let input = {
+    nums: [1, 2, 3],
+    chars: ['T', 'N', 'M']
+  };
+  
+  let iterator = Iterator.zipKeyed(input);
+  
+  let result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+  assert.sameValue(result.value.nums, 1, "First value for 'nums' should be 1");
+  assert.sameValue(result.value.chars, 'T', "First value for 'chars' should be 'T'");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+  assert.sameValue(result.value.nums, 2, "Second value for 'nums' should be 2");
+  assert.sameValue(result.value.chars, 'N', "Second value for 'chars' should be 'N'");
+  
+  result = iterator.next();
+  assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+  assert.sameValue(result.value.nums, 3, "Third value for 'nums' should be 3");
+  assert.sameValue(result.value.chars, 'M', "Third value for 'chars' should be 'M'");
+  
+  result = iterator.next();
+  assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+  assert.sameValue(result.done, true, "Iterator should be done after all elements are consumed");
+  
+  reportCompare(0, 0);
+  

--- a/zip_test/arg-lengths-all-modes.js
+++ b/zip_test/arg-lengths-all-modes.js
@@ -1,0 +1,64 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip respects the different modes: shortest, longest, and strict.
+info: |
+  - In "shortest" mode (default), the iterator stops when the shortest iterable is exhausted.
+  - In "longest" mode, padding is used when shorter iterables are exhausted.
+  - In "strict" mode, an error is thrown if the iterables do not have the same length.
+features: [iterator-sequencing]
+---*/
+
+let longer = [1, 2, 3, 4];
+let shorter = ['a', 'b'];
+
+// Default mode ("shortest")
+let iterator = Iterator.zip([longer, shorter]);
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a'], "First zipped value should be [1, 'a']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b'], "Second zipped value should be [2, 'b']");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+// Should stop because `shorter` is exhausted
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after shortest iterable is exhausted");
+
+// "longest" mode with padding
+iterator = Iterator.zip([longer, shorter], { mode: "longest", padding: [null] });
+
+result = iterator.next();
+assert.compareArray(result.value, [1, 'a'], "First zipped value should be [1, 'a']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b'], "Second zipped value should be [2, 'b']");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3, null], "Padding should be used for longer iterable");
+assert.sameValue(result.done, false, "Iterator should continue after using padding");
+
+result = iterator.next();
+assert.compareArray(result.value, [4, null], "Padding should be used for longer iterable");
+assert.sameValue(result.done, false, "Iterator should continue after using padding");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after longest iterable is exhausted");
+
+// "strict" mode (should throw an error)
+assert.throws(TypeError, () => {
+  iterator = Iterator.zip([longer, shorter], { mode: "strict" });
+  iterator.next();
+}, "Strict mode should throw if iterables have different lengths");
+
+reportCompare(0, 0);

--- a/zip_test/closing-iterators.js
+++ b/zip_test/closing-iterators.js
@@ -1,0 +1,126 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that iterators are properly closed via .return() in various cases.
+info: |
+  - Errors before accessing iterables should not close anything.
+  - Errors from one iterable do not close that iterator, but others may be closed.
+  - "shortest" or "strict" modes close remaining iterators when the shortest is exhausted.
+  - "longest" mode does not close iterators that have already completed.
+  - .return() is called with the correct receiver.
+features: [iterator-sequencing]
+---*/
+
+function createIterator(values, label) {
+    let index = 0;
+    let closed = false;
+    return {
+        next() {
+            if (index < values.length) {
+                return { value: values[index++], done: false };
+            }
+            return { done: true };
+        },
+        return() {
+            closed = true;
+            return { done: true };
+        },
+        get closed() {
+            return closed;
+        }
+    };
+}
+
+// --- ERROR CASES ---
+
+// Case: Error thrown before accessing iterables (should not close anything)
+assert.throws(TypeError, () => {
+    Iterator.zip(null); // Invalid first argument
+});
+
+// Case: Error from one iterable breaking the iterator contract (it should not be closed)
+let badIterable = {
+    [Symbol.iterator]() {
+        return {
+            next() { throw new Error("Iterator contract broken"); },
+            return() { throw new Error("This should not be called"); }
+        };
+    }
+};
+
+let safeIterator = createIterator([1, 2, 3], "safe");
+assert.throws(() => {
+    Iterator.zip([badIterable, safeIterator]).next();
+}, Error, "Iterator contract broken");
+assert.sameValue(safeIterator.closed, true, "Safe iterator should be closed");
+  
+// --- SHORTEST / STRICT MODE ---
+
+let shortIter = createIterator([1, 2], "short");
+let longIter = createIterator([10, 20, 30, 40], "long");
+
+let iterator = Iterator.zip([shortIter, longIter], { mode: "shortest" });
+
+iterator.next(); // [1, 10]
+iterator.next(); // [2, 20]
+let finalResult = iterator.next(); // Should close `longIter`
+
+assert.sameValue(finalResult.done, true, "Iterator should be done after shortest exhausted");
+assert.sameValue(longIter.closed, true, "Long iterator should be closed");
+assert.sameValue(shortIter.closed, false, "Short iterator should NOT be closed");
+
+// --- STRICT MODE ---
+
+shortIter = createIterator([1, 2], "short");
+longIter = createIterator([10, 20, 30, 40], "long");
+
+iterator = Iterator.zip([shortIter, longIter], { mode: "strict" });
+
+iterator.next();
+iterator.next();
+finalResult = iterator.next();
+
+assert.sameValue(finalResult.done, true, "Iterator should be done after shortest exhausted");
+assert.sameValue(longIter.closed, true, "Long iterator should be closed");
+
+// --- LONGEST MODE ---
+
+let longestIter1 = createIterator([1, 2, 3], "longest1");
+let longestIter2 = createIterator([10, 20], "longest2");
+
+iterator = Iterator.zip([longestIter1, longestIter2], { mode: "longest", padding: [null, undefined] });
+
+iterator.next(); // [1, 10]
+iterator.next(); // [2, 20]
+iterator.next(); // [3, undefined]
+
+assert.sameValue(longestIter1.closed, false, "Iterator 1 should NOT be closed (exhausted naturally)");
+assert.sameValue(longestIter2.closed, true, "Iterator 2 should be closed since it exhausted first");
+
+// --- CORRECT RECEIVER FOR .return() ---
+
+let returnSpy = [];
+let trackedIterable = {
+    [Symbol.iterator]() {
+        return {
+            next() { return { value: 42, done: false }; },
+            return() {
+                returnSpy.push(this);
+                return { done: true };
+            }
+        };
+    }
+};
+
+iterator = Iterator.zip([trackedIterable, shortIter]);
+iterator.next();
+iterator.return();
+
+assert.sameValue(returnSpy.length, 1, ".return() should have been called once");
+assert.sameValue(returnSpy[0], trackedIterable[Symbol.iterator](), ".return() should be called on the correct iterator");
+
+reportCompare(0, 0);

--- a/zip_test/empty-argument.js
+++ b/zip_test/empty-argument.js
@@ -1,0 +1,27 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Empty iterable as an argument produces an iterator that is immediately done.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - In "shortest" mode (default), the resulting iterator stops as soon as any iterable is exhausted.
+features: [iterator-sequencing]
+---*/
+
+// empty iterable as argument produces iterator which is finished
+let arg1 = [];
+let arg2 = [1, 2, 3];
+
+let zipResult = Iterator.zip([arg1, arg2])
+
+let iterResult = zipIterator.next();
+
+assert.sameValue(iterResult.done, true);
+
+reportCompare(0, 0);
+

--- a/zip_test/first-arg-longer.js
+++ b/zip_test/first-arg-longer.js
@@ -1,0 +1,33 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip stops when the shortest iterable is exhausted.
+info: |
+  - When given two iterables of different lengths with no options,
+    the iterator stops when the shorter iterable is exhausted.
+features: [iterator-sequencing]
+---*/
+
+let longer = [1, 2, 3, 4];
+let shorter = ['a', 'b'];
+
+let iterator = Iterator.zip([longer, shorter]);
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a'], "First zipped value should be [1, 'a']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b'], "Second zipped value should be [2, 'b']");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+// Should stop because `shorter` is exhausted
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after shortest iterable is exhausted");
+
+reportCompare(0, 0);

--- a/zip_test/first-argument-non-object.js
+++ b/zip_test/first-argument-non-object.js
@@ -1,0 +1,29 @@
+  // |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+  // Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+  // This code is governed by the BSD license found in the LICENSE file.
+
+  /*---
+  esid: sec-iterator.zip
+  description: >
+    Throws a TypeError if the first argument to Iterator.zip is not an object.
+  info: |
+    Iterator.zip ( iterables [, options] )
+
+    - If the first argument is not an object, a TypeError must be thrown.
+  features: [iterator-sequencing]
+  ---*/
+
+  let nonObjects = [
+    null,
+    undefined,
+    42,
+    true,
+    "Hello World!",
+    Symbol("test")
+  ];
+
+  for (let value of nonObjects) {
+    assert.throws(TypeError, () => Iterator.zip(value), `Expected TypeError for value: ${String(value)}`);
+  }
+
+  reportCompare(0, 0);

--- a/zip_test/fresh-outputs.js
+++ b/zip_test/fresh-outputs.js
@@ -1,0 +1,29 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that each object returned by Iterator.zip is a fresh object with a different identity.
+info: |
+  - Each call to `.next()` must return a new object, rather than reusing a single object.
+features: [iterator-sequencing]
+---*/
+
+let iter1 = [1, 2, 3];
+let iter2 = ['a', 'b', 'c'];
+
+let iterator = Iterator.zip([iter1, iter2]);
+
+let firstResult = iterator.next();
+let secondResult = iterator.next();
+
+assert.notSameValue(firstResult, secondResult, "Each result object should have a unique identity");
+assert.notSameValue(firstResult.value, secondResult.value, "Each result's `value` array should be a new object");
+
+let thirdResult = iterator.next();
+assert.notSameValue(secondResult, thirdResult, "Each result object should have a unique identity");
+assert.notSameValue(secondResult.value, thirdResult.value, "Each result's `value` array should be a new object");
+
+reportCompare(0, 0);

--- a/zip_test/iterables-are-strings.js
+++ b/zip_test/iterables-are-strings.js
@@ -1,0 +1,36 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip throws if any iterable is a string, but only after reading padding.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - Strings should not be considered valid iterables.
+  - When mode is "longest", padding must be read before throwing for invalid iterables.
+features: [iterator-sequencing]
+---*/
+
+let optionsGetterCalled = false;
+let options = {
+  mode: "longest",
+  get padding() {
+    optionsGetterCalled = true;
+    return [];
+  }
+};
+
+// Strings should cause a TypeError, but padding should be read first
+assert.throws(TypeError, () => Iterator.zip([[], "string"], options), 
+  "Expected TypeError when a string is passed as an iterable");
+
+assert.sameValue(optionsGetterCalled, true, "Padding should be accessed before throwing for invalid iterables");
+
+// Valid cases should not throw
+Iterator.zip([[], []], { mode: "longest", padding: [] });
+Iterator.zip([[], []], { mode: "shortest" }); // No padding read in shortest mode
+
+reportCompare(0, 0);

--- a/zip_test/iteratorHelper-inputs.js
+++ b/zip_test/iteratorHelper-inputs.js
@@ -1,0 +1,35 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip accepts IteratorHelper instances as input iterables.
+info: |
+  - Zipping IteratorHelpers like those created by .map, .filter, etc., should work like normal.
+features: [iterator-sequencing]
+---*/
+
+let iter1 = Iterator.from([1, 2, 3]).map(x => x * 2); // [2, 4, 6]
+let iter2 = Iterator.from(['a', 'b', 'c']).filter(x => x !== 'z'); // ['a', 'b', 'c']
+
+let zipped = Iterator.zip([iter1, iter2]);
+
+let result = zipped.next();
+assert.compareArray(result.value, [2, 'a']);
+assert.sameValue(result.done, false);
+
+result = zipped.next();
+assert.compareArray(result.value, [4, 'b']);
+assert.sameValue(result.done, false);
+
+result = zipped.next();
+assert.compareArray(result.value, [6, 'c']);
+assert.sameValue(result.done, false);
+
+result = zipped.next();
+assert.sameValue(result.done, true);
+assert.sameValue(result.value, undefined);
+
+reportCompare(0, 0);

--- a/zip_test/mode-from-second.js
+++ b/zip_test/mode-from-second.js
@@ -1,0 +1,25 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that the mode is correctly read from the second argument (options).
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - The mode should be read from options.mode.
+  - If mode is not provided, it defaults to "shortest".
+features: [iterator-sequencing]
+---*/
+
+let iter1 = Iterator.zip([[1, 2], [3, 4]], { mode: "longest" });
+let iter2 = Iterator.zip([[1, 2], [3, 4]], { mode: "shortest" });
+let iter3 = Iterator.zip([[1, 2], [3, 4]]); 
+
+assert.sameValue(iter1.mode, "longest", "Mode should be 'longest' when explicitly set.");
+assert.sameValue(iter2.mode, "shortest", "Mode should be 'shortest' when explicitly set.");
+assert.sameValue(iter3.mode, "shortest", "Mode should default to 'shortest' when not provided.");
+
+reportCompare(0, 0);

--- a/zip_test/mode-not-read.js
+++ b/zip_test/mode-not-read.js
@@ -1,0 +1,49 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that mode is not read if the first argument is not an object.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - If the first argument (iterables) is not an object, a TypeError is thrown.
+  - `mode` must not be accessed if the first argument is invalid.
+features: [iterator-sequencing]
+---*/
+
+let invalidIterables = [
+    null,
+    undefined,
+    420,
+    "notAnObject",
+    true,
+    Symbol("test"),
+    () => {}
+  ];
+  
+  let optionsGetterCalled = false;
+  let options = {
+    get mode() {
+      optionsGetterCalled = true;
+      return "shortest";
+    }
+  };
+  
+  // Ensure TypeError is thrown before mode is accessed
+  for (let value of invalidIterables) {
+    optionsGetterCalled = false;
+    assert.throws(TypeError, () => Iterator.zip(value, options), 
+      `Expected TypeError for first argument: ${String(value)}`);
+    assert.sameValue(optionsGetterCalled, false, "Mode should not be accessed if first argument is invalid");
+  }
+  
+  // Valid case: mode should be read
+  optionsGetterCalled = false;
+  Iterator.zip([[]], options);
+  assert.sameValue(optionsGetterCalled, true, "Mode should be accessed when first argument is valid");
+  
+  reportCompare(0, 0);
+  

--- a/zip_test/mode-object.js
+++ b/zip_test/mode-object.js
@@ -1,0 +1,40 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that the mode option is not coerced to a string and throws for invalid types.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - The mode option must be exactly "shortest", "longest", or "strict".
+  - If mode is not a valid string, a TypeError must be thrown.
+  - Non-string values should not be coerced.
+features: [iterator-sequencing]
+---*/
+
+let invalidModes = [
+    0,
+    1,
+    true,
+    false,
+    "short",
+    "FooBar",
+    {},
+    [],
+    null,
+    undefined,
+    Symbol("test")
+  ];
+  
+  for (let value of invalidModes) {
+    assert.throws(TypeError, () => Iterator.zip([[]], { mode: value }), `Expected TypeError for mode: ${String(value)}`);
+  }
+  
+  Iterator.zip([[]], { mode: "shortest" });
+  Iterator.zip([[]], { mode: "longest" });
+  Iterator.zip([[]], { mode: "strict" });
+  
+  reportCompare(0, 0);

--- a/zip_test/multiple-uneven-lengths.js
+++ b/zip_test/multiple-uneven-lengths.js
@@ -1,0 +1,49 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip works with more than two iterables of different lengths in all modes.
+info: |
+  - Tests shortest, longest, and strict modes with 4 iterables of varying lengths.
+features: [iterator-sequencing]
+---*/
+
+// Inputs of length: 4, 3, 2, 1
+let A = ['a1', 'a2', 'a3', 'a4'];
+let B = ['b1', 'b2', 'b3'];
+let C = ['c1', 'c2'];
+let D = ['d1'];
+
+// --- Shortest mode (default) ---
+let iter = Iterator.zip([A, B, C, D]);
+
+let result = iter.next();
+assert.compareArray(result.value, ['a1', 'b1', 'c1', 'd1']);
+result = iter.next();
+assert.sameValue(result.done, true);
+
+// --- Longest mode with explicit padding ---
+iter = Iterator.zip([A, B, C, D], { mode: "longest", padding: ['xA', 'xB', 'xC', 'xD'] });
+
+let expected = [
+  ['a1', 'b1', 'c1', 'd1'],
+  ['a2', 'b2', 'c2', 'xD'],
+  ['a3', 'b3', 'xC', 'xD'],
+  ['a4', 'xB', 'xC', 'xD']
+];
+
+for (let i = 0; i < expected.length; i++) {
+  result = iter.next();
+  assert.compareArray(result.value, expected[i], `Zipped value at index ${i} should match`);
+}
+assert.sameValue(iter.next().done, true);
+
+// --- Strict mode should throw ---
+assert.throws(TypeError, () => {
+  Iterator.zip([A, B, C, D], { mode: "strict" }).next();
+});
+
+reportCompare(0, 0);

--- a/zip_test/padding-behaviour.js
+++ b/zip_test/padding-behaviour.js
@@ -1,0 +1,61 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Behavior of the padding iterator in Iterator.zip.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - If the padding iterator completes before all other iterators, `next` should not be called again.
+  - If the padding iterator does not complete early, its `.return()` should be called.
+features: [iterator-sequencing]
+---*/
+
+let log = [];
+
+let shortPadding = {
+  next() {
+    log.push("shortPadding.next");
+    return { done: true };
+  },
+  return() {
+    log.push("shortPadding.return");
+  },
+  [Symbol.iterator]() {
+    return this;
+  }
+};
+
+let longPadding = {
+  count: 0,
+  next() {
+    log.push("longPadding.next");
+    this.count++;
+    return { value: "pad", done: this.count >= 10 }; 
+  },
+  return() {
+    log.push("longPadding.return");
+  },
+  [Symbol.iterator]() {
+    return this;
+  }
+};
+
+let iteratorShort = Iterator.zip([[1, 2, 3], ["a", "b", "c", "d"]], { mode: "longest", padding: shortPadding });
+let resultShort = iteratorShort.next();
+assert.sameValue(resultShort.done, false);
+assert.sameValue(resultShort.value.length, 2);
+assert.sameValue(log.includes("shortPadding.return"), false, "shortPadding.return should not be called");
+
+log = [];
+
+let iteratorLong = Iterator.zip([[1, 2, 3], ["a", "b", "c", "d"]], { mode: "longest", padding: longPadding });
+let resultLong = iteratorLong.next();
+assert.sameValue(resultLong.done, false);
+assert.sameValue(resultLong.value.length, 2);
+assert.sameValue(log.includes("longPadding.return"), true, "longPadding.return should be called");
+
+reportCompare(0, 0);

--- a/zip_test/padding-isobject.js
+++ b/zip_test/padding-isobject.js
@@ -1,0 +1,39 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that when mode is "longest", padding must be either undefined or an object.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - If mode is "longest", padding is read from options.padding.
+  - If padding is neither undefined nor an object, a TypeError must be thrown.
+features: [iterator-sequencing]
+---*/
+
+let invalidPaddings = [
+    0,
+    1,
+    true,
+    false,
+    "string",  // Strings should not be allowed as padding
+    Symbol("test"),
+    () => {},  // Functions should not be allowed as padding
+  ];
+  
+  // Test invalid padding values
+  for (let value of invalidPaddings) {
+    assert.throws(TypeError, () => Iterator.zip([[]], { mode: "longest", padding: value }), 
+      `Expected TypeError for padding: ${String(value)}`);
+  }
+  
+  // Valid cases should not throw
+  Iterator.zip([[]], { mode: "longest", padding: undefined });
+  Iterator.zip([[]], { mode: "longest", padding: {} }); // Empty object is valid
+  Iterator.zip([[]], { mode: "longest", padding: [] }); // Arrays are valid objects
+  
+  reportCompare(0, 0);
+  

--- a/zip_test/padding-read-longest.js
+++ b/zip_test/padding-read-longest.js
@@ -1,0 +1,39 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that padding is read if and only if mode is "longest".
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - If mode is "longest", padding is read from options.padding.
+  - If mode is not "longest", padding must not be accessed.
+features: [iterator-sequencing]
+---*/
+
+// Padding should be read when mode is "longest"
+let paddingAccessed = false;
+let paddingObject = {
+  [Symbol.iterator]() {
+    paddingAccessed = true;
+    return [].values();
+  }
+};
+
+Iterator.zip([[]], { mode: "longest", padding: paddingObject });
+assert.sameValue(paddingAccessed, true, "Padding should be accessed when mode is 'longest'");
+
+// Padding should not be read when mode is "shortest" or "strict":
+paddingAccessed = false;
+Iterator.zip([[]], { mode: "shortest", padding: paddingObject });
+assert.sameValue(paddingAccessed, false, "Padding should not be accessed when mode is 'shortest'");
+
+
+paddingAccessed = false;
+Iterator.zip([[]], { mode: "strict", padding: paddingObject });
+assert.sameValue(paddingAccessed, false, "Padding should not be accessed when mode is 'strict'");
+
+reportCompare(0, 0);

--- a/zip_test/padding-three-iterables.js
+++ b/zip_test/padding-three-iterables.js
@@ -1,0 +1,96 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that in "longest" mode, Iterator.zip correctly applies padding with three iterables.
+info: |
+  - When mode is "longest", shorter iterables are padded.
+  - Padding defaults to undefined if not provided.
+  - If padding is given, it applies only where necessary.
+features: [iterator-sequencing]
+---*/
+
+// Case 1: Explicit padding for all iterables
+let iter1 = [1, 2];
+let iter2 = ['a'];
+let iter3 = [true, false, false, true];
+let iter4 = ['X', 'Y', 'Z'];
+
+let iterator = Iterator.zip([iter1, iter2, iter3, iter4], { mode: "longest", padding: ['P1', 'P2', 'P3', 'P4'] });
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true, 'X'], "First zipped value should be [1, 'a', true, 'X']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'P2', false, 'Y'], "Second zipped value should use explicit padding");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, ['P1', 'P2', false, 'Z'], "Third zipped value should pad shorter iterables");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.compareArray(result.value, ['P1', 'P2', true, 'P4'], "Fourth zipped value should continue padding");
+assert.sameValue(result.done, false, "Iterator should not be done after fourth next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+// Case 2: Some iterables have explicit padding, others default to undefined
+iter1 = [1, 2, 3];
+iter2 = ['a'];
+iter3 = [true, false];
+iter4 = ['X', 'Y'];
+
+iterator = Iterator.zip([iter1, iter2, iter3, iter4], { mode: "longest", padding: ['PAD1', 'PAD2'] });
+
+result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true, 'X'], "First zipped value should be [1, 'a', true, 'X']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'PAD2', false, 'Y'], "Second zipped value should pad iter2 with 'PAD2'");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3, 'PAD2', undefined, undefined], "Third zipped value should pad iter3 and iter4 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+// Case 3: No explicit padding, should default to undefined
+iter1 = [1, 2];
+iter2 = ['a', 'b', 'c'];
+iter3 = [true];
+iter4 = ['X', 'Y', 'Z', 'W'];
+
+iterator = Iterator.zip([iter1, iter2, iter3, iter4], { mode: "longest" });
+
+result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true, 'X'], "First zipped value should be [1, 'a', true, 'X']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b', undefined, 'Y'], "Second zipped value should pad iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [undefined, 'c', undefined, 'Z'], "Third zipped value should pad iter1 and iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [undefined, undefined, undefined, 'W'], "Fourth zipped value should pad iter1, iter2, iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after fourth next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+reportCompare(0, 0);

--- a/zip_test/padding-when-mode-longest.js
+++ b/zip_test/padding-when-mode-longest.js
@@ -1,0 +1,89 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that in "longest" mode, Iterator.zip correctly applies padding.
+info: |
+  - When mode is "longest", shorter iterables are padded.
+  - Padding defaults to undefined if not provided.
+  - If padding is given, it applies only where necessary.
+features: [iterator-sequencing]
+---*/
+
+// Case 1: Explicit padding for all iterables
+let iter1 = [1, 2];
+let iter2 = ['a'];
+let iter3 = [true, false, false, true];
+
+let iterator = Iterator.zip([iter1, iter2, iter3], { mode: "longest", padding: ['X', 'Y', 'Z'] });
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true], "First zipped value should be [1, 'a', true]");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'Y', false], "Second zipped value should use explicit padding");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, ['X', 'Z', false], "Third zipped value should pad shorter iterables");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.compareArray(result.value, ['X', 'Z', true], "Fourth zipped value should continue padding");
+assert.sameValue(result.done, false, "Iterator should not be done after fourth next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+// Case 2: Some iterables have explicit padding, others default to undefined
+iter1 = [1, 2, 3];
+iter2 = ['a'];
+iter3 = [true, false];
+
+iterator = Iterator.zip([iter1, iter2, iter3], { mode: "longest", padding: ['PAD'] });
+
+result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true], "First zipped value should be [1, 'a', true]");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'PAD', false], "Second zipped value should pad iter2 with 'PAD'");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3, 'PAD', undefined], "Third zipped value should pad iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+// Case 3: No explicit padding, should default to undefined
+iter1 = [1, 2];
+iter2 = ['a', 'b', 'c'];
+iter3 = [true];
+
+iterator = Iterator.zip([iter1, iter2, iter3], { mode: "longest" });
+
+result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true], "First zipped value should be [1, 'a', true]");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b', undefined], "Second zipped value should pad iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [undefined, 'c', undefined], "Third zipped value should pad iter1 and iter3 with undefined");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+reportCompare(0, 0);

--- a/zip_test/prototype.js
+++ b/zip_test/prototype.js
@@ -1,0 +1,20 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Iterator.zip result has [[Prototype]] set to %IteratorHelperPrototype%.
+info: |
+  - The prototype of the resulting iterator should be %IteratorHelperPrototype%.
+  - %IteratorHelperPrototype% is the same as Object.getPrototypeOf(Iterator.from([]).take(0)).
+features: [iterator-sequencing]
+---*/
+
+let proto = Object.getPrototypeOf(Iterator.from([]).take(0));
+let zipped = Iterator.zip([[], []]);
+
+assert.sameValue(Object.getPrototypeOf(zipped), proto, "Iterator.zip result should have %IteratorHelperPrototype% as prototype");
+
+reportCompare(0, 0);

--- a/zip_test/returns-array.js
+++ b/zip_test/returns-array.js
@@ -1,0 +1,32 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that each value returned by Iterator.zip is an array.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - Each value produced by the iterator should be an array containing elements from each input iterable.
+features: [iterator-sequencing]
+---*/
+let arg1 = ['a', 'b', 'c'];
+let arg2 = [1, 2, 3];
+
+let iter = Iterator.zip([arg1, arg2]);
+
+let result1 = iter.next();
+assert.sameValue(Array.isArray(result1.value), true, "First result should be an array");
+
+let result2 = iter.next();
+assert.sameValue(Array.isArray(result2.value), true, "Second result should be an array");
+
+let result3 = iter.next();
+assert.sameValue(Array.isArray(result3.value), true, "Third result should be an array");
+
+let result4 = iter.next();
+assert.sameValue(result4.done, true, "Iterator should be finished after three results");
+
+reportCompare(0, 0);

--- a/zip_test/second-arg-longer.js
+++ b/zip_test/second-arg-longer.js
@@ -1,0 +1,33 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip stops when the shortest iterable is exhausted.
+info: |
+  - When given two iterables of different lengths with no options,
+    the iterator stops when the shorter iterable is exhausted.
+features: [iterator-sequencing]
+---*/
+
+let shorter = [1, 2];
+let longer = ['a', 'b', 'c', 'd'];
+
+let iterator = Iterator.zip([shorter, longer]);
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a'], "First zipped value should be [1, 'a']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b'], "Second zipped value should be [2, 'b']");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+// Should stop because `shorter` is exhausted
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after shortest iterable is exhausted");
+
+reportCompare(0, 0);

--- a/zip_test/second-argument-non-object.js
+++ b/zip_test/second-argument-non-object.js
@@ -1,0 +1,32 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Throws a TypeError if the second argument to Iterator.zip is not an object and not null/undefined.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - If options is provided, it must be either an object or null/undefined.
+  - Any other type should result in a TypeError.
+features: [iterator-sequencing]
+---*/
+let arg1 = [1, 2, 3]
+let invalids = [
+  42,
+  false,
+  "Hello Mozilla!",
+  Symbol("test")
+];
+
+for (let value of invalids) {
+  assert.throws(TypeError, () => Iterator.zip(arg1, value), `Expected TypeError for value: ${String(value)}`);
+}
+// Valids
+Iterator.zip([arg1], undefined);
+Iterator.zip([arg1], null);
+Iterator.zip([arg1], {}); 
+
+reportCompare(0, 0);

--- a/zip_test/side-effect-order.js
+++ b/zip_test/side-effect-order.js
@@ -1,0 +1,77 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures the correct order of side effects in Iterator.zip.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - Side effects should occur in a well-defined order.
+  - This test makes all side effects observable and checks the totality.
+features: [iterator-sequencing]
+---*/
+
+let log = [];
+
+// Create a getter-tracked options object
+let options = {
+  get mode() {
+    log.push("options.mode accessed");
+    return "longest";
+  },
+  get padding() {
+    log.push("options.padding accessed");
+    return [];
+  }
+};
+
+// Create an iterable with observable side effects
+function createTrackedIterable(name) {
+  return {
+    [Symbol.iterator]() {
+      log.push(`${name} iterator accessed`);
+      return {
+        next() {
+          log.push(`${name} next() called`);
+          return { done: true };
+        },
+        return() {
+          log.push(`${name} return() called`);
+          return { done: true };
+        }
+      };
+    }
+  };
+}
+
+// Create multiple tracked iterables
+let iter1 = createTrackedIterable("iter1");
+let iter2 = createTrackedIterable("iter2");
+
+// Call Iterator.zip and observe side effects
+log.push("Calling Iterator.zip");
+let iterator = Iterator.zip([iter1, iter2], options);
+
+// Assert immediately after calling .zip
+assert.compareArray(log, [
+  "Calling Iterator.zip",
+  "options.mode accessed",
+  "options.padding accessed",
+  "iter1 iterator accessed",
+  "iter2 iterator accessed"
+], "Side effects should occur in the expected order before calling .next");
+
+// Clear log and call .next on the result
+log = [];
+iterator.next();
+
+// Assert after calling .next
+assert.compareArray(log, [
+  "iter1 next() called",
+  "iter2 next() called"
+], "Side effects should occur in the expected order after calling .next");
+
+reportCompare(0, 0);

--- a/zip_test/strict-same-length.js
+++ b/zip_test/strict-same-length.js
@@ -1,0 +1,38 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that in strict mode, Iterator.zip consumes all iterators fully when lengths match.
+info: |
+  - In "strict" mode, all iterators must have the same length.
+  - When one iterator completes, .next() must still be called on the rest to check for completion.
+features: [iterator-sequencing]
+---*/
+
+let first = [1, 2, 3];
+let second = ['a', 'b', 'c'];
+let third = [true, false, null];
+
+let iterator = Iterator.zip([first, second, third], { mode: "strict" });
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'a', true], "First zipped value should be [1, 'a', true]");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'b', false], "Second zipped value should be [2, 'b', false]");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3, 'c', null], "Third zipped value should be [3, 'c', null]");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+// Ensure all iterators are fully consumed
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after full consumption");
+assert.sameValue(result.done, true, "Iterator should be done after all iterables are exhausted");
+
+reportCompare(0, 0);

--- a/zip_test/zero-iterables-padding.js
+++ b/zip_test/zero-iterables-padding.js
@@ -1,0 +1,36 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  In longest mode, Iterator.zip([]) with a non-empty padding iterable should yield no values.
+info: |
+  - Even if padding is provided, no zipping occurs when input iterable list is empty.
+features: [iterator-sequencing]
+---*/
+
+let callCount = 0;
+let padding = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        callCount++;
+        return { value: "pad", done: callCount > 5 }; // Emit some padding
+      },
+      return() {
+        throw new Error("Should not be called");
+      }
+    };
+  }
+};
+
+let zipped = Iterator.zip([], { mode: "longest", padding });
+
+let result = zipped.next();
+assert.sameValue(result.done, true);
+assert.sameValue(result.value, undefined);
+assert.sameValue(callCount, 0, "Padding should not be read at all when no iterables are zipped");
+
+reportCompare(0, 0);

--- a/zip_test/zip-one-thing.js
+++ b/zip_test/zip-one-thing.js
@@ -1,0 +1,36 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip can handle exactly one iterable.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - When given a single iterable, it should yield single-element arrays.
+features: [iterator-sequencing]
+---*/
+
+let input = [1, 2, 3];
+
+let iterator = Iterator.zip([input]);
+
+let result = iterator.next();
+assert.compareArray(result.value, [1], "First value should be [1]");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2], "Second value should be [2]");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3], "Third value should be [3]");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after all elements are consumed");
+
+reportCompare(0, 0);

--- a/zip_test/zip-two-same-length.js
+++ b/zip_test/zip-two-same-length.js
@@ -1,0 +1,37 @@
+// |reftest| shell-option(--enable-iterator-sequencing) skip-if(!Iterator.zip||!xulRuntime.shell) -- iterator-sequencing is not enabled unconditionally, requires shell-options
+// Copyright (C) 2025 Theodor Nissen-Meyer. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-iterator.zip
+description: >
+  Ensures that Iterator.zip correctly zips two iterables with the same number of elements.
+info: |
+  Iterator.zip ( iterables [, options] )
+
+  - When given two iterables of the same length, it should pair corresponding elements.
+features: [iterator-sequencing]
+---*/
+
+let input1 = [1, 2, 3];
+let input2 = ['T', 'N', 'M'];
+
+let iterator = Iterator.zip([input1, input2]);
+
+let result = iterator.next();
+assert.compareArray(result.value, [1, 'T'], "First zipped value should be [1, 'T']");
+assert.sameValue(result.done, false, "Iterator should not be done after first next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [2, 'N'], "Second zipped value should be [2, 'N']");
+assert.sameValue(result.done, false, "Iterator should not be done after second next()");
+
+result = iterator.next();
+assert.compareArray(result.value, [3, 'M'], "Third zipped value should be [3, 'M']");
+assert.sameValue(result.done, false, "Iterator should not be done after third next()");
+
+result = iterator.next();
+assert.sameValue(result.value, undefined, "Iterator should return undefined after exhaustion");
+assert.sameValue(result.done, true, "Iterator should be done after all elements are consumed");
+
+reportCompare(0, 0);


### PR DESCRIPTION
Add all specified tests for Iterator.zip and Iterator.zipKeyed. Also 5 additional not previously specified, see below.

zip:
empty iterable as argument produces iterator which is finished
cases for the iterable returned by padding:
it returns { done: true } in fewer steps than there are things to be zipped
in this case next should not be called any more times
and .return should not be looked at or called
it does not return { done: true } within the number of steps as there are things to be zipped
in this case its .return should be called
result objects are arrays

zipKeyed:
object with no own-enumerable keys as argument produces iterator which is finished
confirm inherited keys are not used
confirm non-enumerable keys are not used
make sure that output objects have correct attributes for the properties
output properties are writable/configurable, even if they were not on the input
output objects inherit from null
order of properties reported by Object.keys() is the same as they were on the first argument
tests with Symbol-named properties

both:
throws if the first argument is not an object (including if it is a string)
throws if the second argument is not an object and not null/undefined
mode is read from second argument
mode is not coerced to a string
padding is read if and only if mode is "longest"
when mode is "longest", throws if padding is not undefined and not an object (including if it is a string)
mode is not read if the first argument is not an object
throws if any iterables are strings (after reading the padding)
order of side effects in general (there are lots of these, just make something that makes every single side-effect observable and assert on the totality)
should assert immediately after calling .zip, and also after calling .next on the result
can zip exactly one thing
can zip exactly two things with the same number of elements
can zip two iterable things of different length with no options object (which behaves like shortest)
need tests for first thing is longer, and second thing is longer
as above but with each of the three modes explicitly
when mode is strict, and the lengths are the same, once the first iterator completes .next on the rest, to check done-ness
when mode is longest, correct padding is used
including with explicit padding for everything, with padding for some but not all things, and when padding is undefined
as above but with three things
output objects are "fresh", i.e., different identity for first vs second thing returned
tests for closing the correct iterators in the various cases:
all the error cases (not going to enumerate these but there's a lot)
when the error is caused by one of the iterables breaking the iterator contract, that iterator is not closed
with "shortest" or "strict", after the shortest thing is exhausted
including when the shortest thing is in the middle of the list
when .return is called explicitly
including when mode is "longest" and some iterators have already finished (in which case they are not closed)
tests should assert that .return [is invoked with the correct receiver](https://github.com/WebKit/WebKit/commit/a6b23120280d34f77b9276d4f6e7414eb58c6f39)
resulting iterator has [[Prototype]] of %IteratorHelperPrototype% (i.e., Object.getPrototypeOf(Iterator.from([]).take(0)))

Additional tests:
Zip:
Input iterables that are iteratorHelpers
- Ensures that Iterator.zip accepts IteratorHelper instances as input iterables.
Zipping More Than Two Inputs With Uneven Lengths
-  Ensures that Iterator.zip works with more than two iterables of different lengths in all modes.
Zipping Zero Iterables With Non-Empty Padding (Longest Mode)
- In longest mode, Iterator.zip([]) with a non-empty padding iterable should yield no values.

ZipKeyed:
 Property enumeration respects JS key ordering rules
-   Iterator.zipKeyed respects JS property key enumeration order:
-   integer-like keys in ascending order, then string keys in insertion order. 
All values are empty iterables, should be immediately done
- Iterator.zipKeyed returns a finished iterator immediately when all property values are empty.
